### PR TITLE
Add macOS DMG build tooling

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -1,0 +1,45 @@
+name: Build macOS DMG
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  dmg:
+    name: macOS DMG (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-13
+          - macos-14
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Temurin JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Ensure Ant is available
+        run: |
+          if ! command -v ant >/dev/null 2>&1; then
+            brew update
+            brew install ant
+          fi
+
+      - name: Build distribution image
+        run: |
+          cd Impro-Visor
+          ./packaging/macos/build_dmg.sh
+
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Impro-Visor-${{ matrix.os }}-dmg
+          path: Impro-Visor/build/distributions/*.dmg
+          if-no-files-found: error

--- a/README.txt
+++ b/README.txt
@@ -47,6 +47,28 @@ The sources are currently maintained on github:
 
     https://github.com/Impro-Visor/Impro-Visor
 
+==============================
+Building a macOS disk image
+==============================
+
+A helper script is provided to build a self-contained runtime image for macOS
+using the JDK-provided `jpackage` tool. To generate a DMG on a macOS host with
+Ant and JDK 14 (or newer) available, run:
+
+    cd Impro-Visor
+    ./packaging/macos/build_dmg.sh
+
+The script compiles the distribution with Ant, invokes `jpackage` to bundle a
+modern Java runtime, and writes the resulting DMG to `build/distributions`.
+The archive name includes the application version and local CPU architecture,
+which makes it straightforward to publish both Intel and Apple Silicon builds.
+
+Continuous integration support is available via the `Build macOS DMG` workflow
+in `.github/workflows/macos-dmg.yml`. The workflow runs on both Intel and
+Apple Silicon GitHub-hosted runners and uploads the generated DMG files as
+artifacts when triggered manually or when a Git tag following the `v*` pattern
+is pushed.
+
 Once the program is installed, there should be a launcher
 
     Impro-Visor

--- a/build.xml
+++ b/build.xml
@@ -502,12 +502,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
     <mkdir dir="${appdir}/Contents/MacOS" />
     <mkdir dir="${appdir}/Contents/Resources" />
     <mkdir dir="${appdir}/Contents/Resources/Java" />
-    <mkdir dir="${dist-mac}/vocab" />
-    <mkdir dir="${dist-mac}/styles" />
-    <mkdir dir="${dist-mac}/styleExtract" />
-    <mkdir dir="${dist-mac}/midi" />
-    <mkdir dir="${dist-mac}/leadsheets" />
-    
+    <property name="macJavaRoot" value="${appdir}/Contents/Resources/Java" />
+
     <copy file="${packagingDir}/JavaApplicationStub"
         todir="${appdir}/Contents/MacOS"/>
     <exec executable="chmod">
@@ -522,55 +518,55 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
         
     <copy file="${packagingDir}/PkgInfo"
         todir="${dist-mac}/${appName}.app/Contents"/>
-        
+
     <copy file="${distDir}/improvisor.jar"
-        todir="${appdir}/Contents/Resources/Java"/>
-        
-    <copy todir="${dist-mac}/vocab">
+        todir="${macJavaRoot}"/>
+
+    <copy todir="${macJavaRoot}/vocab">
         <fileset dir="${vocabDir}" includes="**/*.voc HeadData.data" />
     </copy>
-    
-    <copy todir="${dist-mac}/vocab">
+
+    <copy todir="${macJavaRoot}/vocab">
         <fileset dir="${vocabDir}" includes="**/*" />
     </copy>
-    
-    <copy todir="${dist-mac}">
+
+    <copy todir="${macJavaRoot}">
         <fileset dir="" includes="LICENSE.txt README.txt" />
     </copy>
 
-    <copy todir="${dist-mac}/vocab">
+    <copy todir="${macJavaRoot}/vocab">
         <fileset dir="${vocabDir}" includes="**/*.grammar **/*.soloist" />
     </copy>
 
-    <copy todir="${dist-mac}/vocab">
+    <copy todir="${macJavaRoot}/vocab">
         <fileset dir="${vocabDir}" includes="**/*.prefs" />
     </copy>
-    
-    <copy todir="${dist-mac}/vocab">
+
+    <copy todir="${macJavaRoot}/vocab">
         <fileset dir="${vocabDir}" includes="**/*.xml" />
     </copy>
-    
-    <copy todir="${dist-mac}/leadsheets">
+
+    <copy todir="${macJavaRoot}/leadsheets">
         <fileset dir="${lsDir}" includes="**/*.ls" />
     </copy>
-    
-    <copy todir="${dist-mac}/styles">
+
+    <copy todir="${macJavaRoot}/styles">
         <fileset dir="${styleDir}" includes="**/*.sty" />
     </copy>
-    
-    <copy todir="${dist-mac}/styleExtract">
+
+    <copy todir="${macJavaRoot}/styleExtract">
         <fileset dir="${styleExtractDir}" includes="**/*.ls **/*.mid **/*.MID" />
     </copy>
-    
-     <copy todir="${dist-mac}/midi">
+
+     <copy todir="${macJavaRoot}/midi">
         <fileset dir="${midiDir}" includes="**/*.mid **/*.MID" />
     </copy>
-    
-    <copy todir="${dist-mac}">
+
+    <copy todir="${macJavaRoot}">
         <fileset dir="${miscDir}" includes="**/*.*" />
     </copy>
-   
-    
+
+
 </target>
 
 <target name="dist-win" depends="dist">

--- a/packaging/Info.plist
+++ b/packaging/Info.plist
@@ -46,7 +46,9 @@
                 <dict>
                     <key>apple.laf.useScreenMenuBar</key>
                     <string>true</string>
+                    <key>improvisor.install.root</key>
+                    <string>$JAVAROOT</string>
                 </dict>
-	</dict>
+        </dict>
 </dict>
 </plist>

--- a/packaging/macos/build_dmg.sh
+++ b/packaging/macos/build_dmg.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${PROJECT_ROOT}"
+
+APP_NAME="Impro-Visor"
+OUTPUT_DIR="${PROJECT_ROOT}/build/distributions"
+REQUESTED_VERSION=""
+SKIP_CLEAN="false"
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [options]
+
+Options:
+  --app-version <version>   Override the application version embedded in the DMG name.
+  --dest <path>             Directory where the DMG should be written (default: build/distributions).
+  --skip-clean              Do not run 'ant clean' before building the distribution.
+  -h, --help                Show this help message.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app-version)
+      [[ $# -ge 2 ]] || { echo "Missing value for --app-version" >&2; exit 1; }
+      REQUESTED_VERSION="$2"
+      shift 2
+      ;;
+    --dest)
+      [[ $# -ge 2 ]] || { echo "Missing value for --dest" >&2; exit 1; }
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --skip-clean)
+      SKIP_CLEAN="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+command -v ant >/dev/null 2>&1 || { echo "ant is required to build the distribution." >&2; exit 1; }
+command -v jpackage >/dev/null 2>&1 || { echo "jpackage is required to create the DMG." >&2; exit 1; }
+
+if [[ "${SKIP_CLEAN}" != "true" ]]; then
+  ant clean
+fi
+
+ant dist
+
+DEFAULT_VERSION=""
+if [[ -n "${REQUESTED_VERSION}" ]]; then
+  APP_VERSION="${REQUESTED_VERSION}"
+else
+  if [[ -x /usr/libexec/PlistBuddy && -f packaging/Info.plist ]]; then
+    DEFAULT_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" packaging/Info.plist 2>/dev/null || true)
+  fi
+  if [[ -z "${DEFAULT_VERSION}" ]]; then
+    if [[ -f src/imp/ImproVisor.java ]]; then
+      DEFAULT_VERSION=$(grep -E "public static final String version" src/imp/ImproVisor.java | sed -E 's/.*"([^"]+)".*/\1/' || true)
+    fi
+  fi
+  APP_VERSION="${DEFAULT_VERSION:-10.2}"
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+
+APP_IMAGE_DIR="improvisor1020"
+if [[ ! -d "${APP_IMAGE_DIR}" ]]; then
+  echo "Expected distribution directory '${APP_IMAGE_DIR}' was not created." >&2
+  exit 1
+fi
+
+DMG_BASENAME="${APP_NAME}-${APP_VERSION}"
+ARCH_NAME="$(uname -m)"
+TARGET_DMG="${OUTPUT_DIR}/${DMG_BASENAME}-macOS-${ARCH_NAME}.dmg"
+
+rm -f "${OUTPUT_DIR}/${APP_NAME}-${APP_VERSION}.dmg" "${TARGET_DMG}"
+
+jpackage \
+  --type dmg \
+  --name "${APP_NAME}" \
+  --input "${APP_IMAGE_DIR}" \
+  --main-jar improvisor.jar \
+  --main-class imp.ImproVisor \
+  --app-version "${APP_VERSION}" \
+  --icon packaging/ImproVisor.icns \
+  --dest "${OUTPUT_DIR}" \
+  --java-options "-Dimprovisor.install.root=\$APPDIR/app" \
+  --vendor "Impro-Visor Project" \
+  --mac-package-name "${APP_NAME}" \
+  --mac-package-identifier "com.improvisor.app"
+
+if [[ -f "${OUTPUT_DIR}/${APP_NAME}-${APP_VERSION}.dmg" ]]; then
+  mv "${OUTPUT_DIR}/${APP_NAME}-${APP_VERSION}.dmg" "${TARGET_DMG}"
+fi
+
+echo "Created DMG: ${TARGET_DMG}"

--- a/src/imp/ImproVisor.java
+++ b/src/imp/ImproVisor.java
@@ -583,7 +583,7 @@ public static void establishUserDirectory(File homeDir)
 
 public static void copyDir(String subDirName, File homeDir)
   {
-    File masterDir = new File(subDirName);
+    File masterDir = new File(getInstallationDirectory(), subDirName);
 
     File userDir = new File(homeDir, subDirName);
 
@@ -593,9 +593,33 @@ public static void copyDir(String subDirName, File homeDir)
           }
         catch( IOException e )
           {
-            ErrorLog.log(ErrorLog.SEVERE, "Error in copying folder " 
+            ErrorLog.log(ErrorLog.SEVERE, "Error in copying folder "
                            + subDirName + " to user directory.");
           }
+  }
+
+private static final String INSTALL_ROOT_PROPERTY = "improvisor.install.root";
+
+private static File installationDirectory;
+
+public static synchronized File getInstallationDirectory()
+  {
+    if( installationDirectory == null )
+      {
+        String override = System.getProperty(INSTALL_ROOT_PROPERTY);
+
+        if( override != null && override.trim().length() > 0 )
+          {
+            installationDirectory = new File(override.trim());
+          }
+        else
+          {
+            String cwd = System.getProperty("user.dir", ".");
+            installationDirectory = new File(cwd);
+          }
+      }
+
+    return installationDirectory;
   }
 
 


### PR DESCRIPTION
## Summary
- add a macOS build script that uses `jpackage` to create DMGs with an embedded runtime
- ensure the application finds its bundled resources by honoring a new `improvisor.install.root` system property and packaging the macOS app bundle accordingly
- document the workflow and provide a GitHub Action that produces Apple Silicon and Intel DMG artifacts

## Testing
- `ant dist-mac` *(fails: java.net.SocketException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d453798d288329bc02f2e867a41dc7